### PR TITLE
Update 负载均衡计费常见问题.md

### DIFF
--- a/cn.zh-CN/常见问题/负载均衡计费常见问题.md
+++ b/cn.zh-CN/常见问题/负载均衡计费常见问题.md
@@ -2,7 +2,7 @@
 
 ## 1. 负载均衡如何计费？ {#section_tjm_3mx_wdb .section}
 
-参考[计费说明](../cn.zh-CN/产品定价/按量计费.md#)。
+参考[计费说明](../cn.zh-CN/产品定价/预付费.md#)。
 
 ## 2. 负载均衡是否对入流量计费？ {#section_bhr_jmx_wdb .section}
 


### PR DESCRIPTION
原“计费说明”文档已无效，将链接改为现在“产品定价”目录下的第一篇文档，更为准确。